### PR TITLE
Added docker support for api and web

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,23 @@
+# Use Node.js version 22 as the base image
+FROM node:22
+
+# Set the working directory in the container to /api
+WORKDIR /api
+
+# Copy package.json and package-lock.json from the API folder into the container
+COPY api/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Install nodemon globally
+RUN npm install -g nodemon
+
+# Copy the entire API source code into the container
+COPY api/ .
+
+# Expose the port that your API listens on (adjust if needed)
+EXPOSE 3000
+
+# Use nodemon to run your API.
+CMD ["npm", "run", "nodemon"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: web/Dockerfile
+    ports:
+      - "4200:80"
+  
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    ports:
+      - "3000:3000"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build the Vite React app
+FROM node:22 AS builder
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json for better caching
+COPY web/package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the entire frontend source code
+COPY web/ .
+
+# Build the Vite app
+RUN npm run build
+
+# Stage 2: Serve the built assets with Nginx
+FROM nginx:stable
+
+# Remove default Nginx static files
+RUN rm -rf /usr/share/nginx/html/*
+
+# Copy the built files from the previous stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose port 80 for HTTP traffic
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This pull request introduces Docker support for both the API and the frontend web application. It includes Dockerfiles for each service and a `docker-compose.yml` file to manage the multi-container setup. The key changes are as follows:

### Dockerfile for API:
* Added a `Dockerfile` for the API service using Node.js version 22 as the base image, installing dependencies, and setting up `nodemon` for development.

### Dockerfile for Web:
* Added a multi-stage `Dockerfile` for the frontend web application. The first stage builds the Vite React app, and the second stage serves the built assets with Nginx.

### Docker Compose:
* Added a `docker-compose.yml` file to define services for the web and API, specifying build contexts, Dockerfiles, and port mappings.