### PR TITLE
Testing github action

### DIFF
--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -13,15 +13,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Replace placeholders in .env file with GitHub Secrets
+        shell: pwsh
         run: |
-          sed -i "s/your_api_port/3000/" api/.env
-          sed -i "s/your_db_user/${{ secrets.DB_USER }}/" api/.env
-          sed -i "s/your_db_password/${{ secrets.DB_PASSWORD }}/" api/.env
-          sed -i "s/your_db_host/${{ secrets.DB_HOST }}/" api/.env
-          sed -i "s/your_db_port/${{ secrets.DB_PORT }}/" api/.env
-          sed -i "s/your_db_name/${{ secrets.DB_NAME }}/" api/.env
-          sed -i "s/your_jwt_secret/${{ secrets.JWT_SECRET }}/" api/.env
-          sed -i "s/your_brevo_api_key/${{ secrets.BREVO_API_KEY }}/" api/.env
+          (Get-Content api/.env) -replace 'your_api_port', '3000' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_user', '${{ secrets.DB_USER }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_password', '${{ secrets.DB_PASSWORD }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_host', '${{ secrets.DB_HOST }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_port', '${{ secrets.DB_PORT }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_name', '${{ secrets.DB_NAME }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_jwt_secret', '${{ secrets.JWT_SECRET }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_brevo_api_key', '${{ secrets.BREVO_API_KEY }}' | Set-Content api/.env
 
       - name: Log in to Docker
         run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"

--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Replace placeholders in .env file with GitHub Secrets
-        shell: pwsh
+        shell: powershell
         run: |
           (Get-Content api/.env) -replace 'your_api_port', '3000' | Set-Content api/.env
           (Get-Content api/.env) -replace 'your_db_user', '${{ secrets.DB_USER }}' | Set-Content api/.env


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/deploy-servers.yml` file. The change updates the shell used for replacing placeholders in the `.env` file from `pwsh` to `powershell`.

* [`.github/workflows/deploy-servers.yml`](diffhunk://#diff-316d465dd65d19cc85b8a61376adb13abab93417a9d4976ad203280b2328893aL16-R16): Changed the shell from `pwsh` to `powershell` for the step that replaces placeholders in the `.env` file with GitHub Secrets.