### PR TITLE
Updating `main` 2025-04-02

### DIFF
--- a/.github/workflows/deploy-servers.yml
+++ b/.github/workflows/deploy-servers.yml
@@ -15,24 +15,17 @@ jobs:
       - name: Replace placeholders in .env file with GitHub Secrets
         shell: powershell
         run: |
-          (Get-Content api/.env) -replace 'your_api_port', '3000' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_db_user', '${{ secrets.DB_USER }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_db_password', '${{ secrets.DB_PASSWORD }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_db_host', '${{ secrets.DB_HOST }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_db_port', '${{ secrets.DB_PORT }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_db_name', '${{ secrets.DB_NAME }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_jwt_secret', '${{ secrets.JWT_SECRET }}' | Set-Content api/.env
-          (Get-Content api/.env) -replace 'your_brevo_api_key', '${{ secrets.BREVO_API_KEY }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_api_port', '${{ secrets.YOUR_API_PORT }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_user', '${{ secrets.YOUR_DB_USER }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_password', '${{ secrets.YOUR_DB_PASSWORD }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_host', '${{ secrets.YOUR_DB_HOST }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_port', '${{ secrets.YOUR_DB_PORT }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_db_name', '${{ secrets.YOUR_DB_NAME }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_jwt_secret', '${{ secrets.YOUR_JWT_SECRET }}' | Set-Content api/.env
+          (Get-Content api/.env) -replace 'your_brevo_api_key', '${{ secrets.YOUR_BREVO_API_KEY }}' | Set-Content api/.env
 
       - name: Log in to Docker
         run: docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
-
-      - name: Build and run services
-        env:
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-        run: echo "Setting up environment variables for Docker Compose"
 
       - name: Rebuild and run containers
         run: docker-compose up -d --build

--- a/api/routes/helpers/authHelper.js
+++ b/api/routes/helpers/authHelper.js
@@ -16,6 +16,7 @@ const Handlebars = require('handlebars');
  * @param {*} res
  */
 const AuthenticateConnection = (req, res) => {
+    winston.info(`Connection authenticated successfully.`, { req });
     res.send(generateResponseBody({}, messages.auth.connectionAuthenticated));
 }
 
@@ -27,26 +28,35 @@ const AuthenticateConnection = (req, res) => {
  */
 const Login = async (req, res) => {
     try {
+        winston.info(`Authenticating user: ${req.body.username}`, { req });
         const user = await dbController.GetUserByUsername(req.body.username);
 
         if (user) {
+            winston.info(`User found: ${user.username}`, { req });
+            winston.info(`Checking password for user: ${user.username}`, { req });
             const isPasswordValid = await bcrypt.compare(req.body.password, user.password);
 
             // Check if password is valid
             if (!isPasswordValid) {
+                winston.error(`Invalid password for user: ${req.body.username}`, { req });
                 return res.status(401).send(generateResponseBody({}, messages.auth.login.invalidPassword));
             }
 
             // Check if user is approved, suspended or deleted
+            winston.info(`Checking user status for user: ${user.username}`, { req });
             if (!user.isApproved) {
+                winston.error(`User not approved: ${user.username}`, { req });
                 return res.status(401).send(generateResponseBody({}, messages.auth.login.accountNotApproved));
             } else if (user.isSuspended) {
+                winston.error(`User suspended: ${user.username}`, { req });
                 return res.status(401).send(generateResponseBody({}, messages.auth.login.accountSuspended));
             } else if (user.isDeleted) {
+                winston.error(`User deleted: ${user.username}`, { req });
                 return res.status(401).send(generateResponseBody({}, messages.auth.login.accountDeleted));
             }
 
             // Generate token
+            winston.info(`Generating token for user: ${user.username}`, { req });
             const token = jwt.sign({
                 userId: user.userId,
                 username: user.username,
@@ -54,6 +64,7 @@ const Login = async (req, res) => {
                 employeeRoleId: user.employeeRoleId,
             }, process.env.JWT_SECRET, { expiresIn: constants.defaultConfigurations.tokenExpiry.accessToken });
 
+            winston.info(`Token generated successfully for user: ${user.username}`, { req });
             return res.status(200).send(generateResponseBody({
                 userId: user.userId,
                 username: user.username,
@@ -63,6 +74,7 @@ const Login = async (req, res) => {
             }, messages.auth.login.success));
 
         } else {
+            winston.error(`Invalid username or password for user: ${req.body.username}`, { req });
             return res.status(401).send(generateResponseBody({}, messages.auth.login.invalidUsernameOrPassword));
         }
 
@@ -80,13 +92,16 @@ const Login = async (req, res) => {
  */
 const GenerateResetToken = async (req, res) => {
     try {
+        winston.info(`Verifying user: ${req.body.username}`, { req });
         const user = await dbController.GetUserByUsername(req.body.username);
 
         if (user) {
             // Generate reset code
+            winston.info(`Generating reset code for user: ${user.username}`, { req });
             const resetCode = Math.floor(10000 + Math.random() * 90000).toString();
 
             // Generate reset token
+            winston.info(`Generating reset token for user: ${user.username}`, { req });
             const ResetCodeToken = jwt.sign({
                 userId: user.userId,
                 username: user.username,
@@ -94,6 +109,7 @@ const GenerateResetToken = async (req, res) => {
             }, process.env.JWT_SECRET, { expiresIn: constants.defaultConfigurations.tokenExpiry.passwordResetToken });
 
             // Update reset code in database
+            winston.info(`Updating reset code in database for user: ${user.username}`, { req });
             const response = await dbController.UpdateResetCode(ResetCodeToken, user.username);
 
             if (response) {
@@ -127,16 +143,16 @@ const GenerateResetToken = async (req, res) => {
                     return res.status(200).send(generateResponseBody({ token: ResetCodeToken, result }, response.message))
                 }
                 winston.error(`Error sending reset code to user: ${user.username}`, { req });
-                return res.status(500).send(generateResponseBody({}, messages.auth.resetToken.failed));
+                return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.resetToken.failed));
             }
             winston.error(`Error registering reset code for user: ${req.body.username}`, { req });
-            return res.status(500).send(generateResponseBody({}, messages.auth.resetToken.failed));
+            return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.resetToken.failed));
         } else {
             winston.error(`No user found with username: ${req.body.username}`, { req });
             return res.status(401).send(generateResponseBody({}, messages.generalResponse.noUserFound));
         }
     } catch (error) {
-        winston.error(`Error generating reset code for user: ${req.body.username}`, { req });
+        winston.error(`Error generating reset code for user: ${req.body.username}, Error: ${error.message}`, { req });
         winston.error(`Error Stack: ${error.stack}`, { req });
         return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.resetToken.failed, error.message));
     }
@@ -151,17 +167,22 @@ const GenerateResetToken = async (req, res) => {
 const VerifyResetToken = async (req, res) => {
     try {
 
+        winston.info(`Verifying user: ${req.authorizedUser.username}`, { req });
         const user = await dbController.GetUserByUsername(req.authorizedUser.username);
 
         if (user) {
 
             // Check if reset code is consistent with the one in the database
+            winston.info(`Verifying reset code for user: ${user.username}`, { req });
             if (req.authorizedUser.code === jwt.verify(user.resetCode, process.env.JWT_SECRET).code && req.body.resetCode === req.authorizedUser.code) {
+                winston.info(`Reset code verified successfully for user: ${user.username}`, { req });
                 return res.status(200).send(generateResponseBody({}, messages.auth.resetToken.tokenVerified));
             }
 
+            winston.error(`Invalid reset code for user: ${user.username}`, { req });
             return res.status(404).send(generateResponseBody({}, messages.auth.resetToken.tokenVerificationFailed));
         } else {
+            winston.error(`No user found with username: ${req.authorizedUser.username}`, { req });
             return res.status(401).send(generateResponseBody({}, messages.generalResponse.noUserFound));
         }
     } catch (error) {
@@ -180,53 +201,75 @@ const ResetPassword = async (req, res) => {
     let transactionStatus = false;
     try {
 
+        winston.info(`Verifying user: ${req.authorizedUser.username}`, { req });
         const user = await dbController.GetUserByUsername(req.authorizedUser.username);
 
         if (user) {
+            winston.info(`User found: ${user.username}`, { req });
 
             if (user.resetCode === null) {
+                winston.error(`Reset code does not exist for user: ${user.username}`, { req });
                 return res.status(403).send(generateResponseBody({}, messages.auth.resetToken.tokenInvalidOrExpired));
             }
 
             // get reset token from database and verify it
+            winston.info(`Validating reset code in DB for corruption for user: ${user.username}`, { req });
             jwt.verify(user.resetCode, process.env.JWT_SECRET, async (err, resetToken) => {
 
                 if (err) {
+                    winston.error(`Reset token is invalid or expired for user: ${user.username}, Error: ${err.message}`, { req });
                     return res.status(403).send(generateResponseBody({}, messages.auth.resetToken.tokenInvalidOrExpired));
                 }
+                winston.info(`Reset token in DB is valid for user: ${user.username}`, { req });
 
                 // Check if reset code is consistent with the one in the database
+                winston.info(`Verifying reset code for user: ${user.username}`, { req });
                 if (req.authorizedUser.code !== req.body.resetCode || !(req.authorizedUser.code === resetToken.code && req.authorizedUser.username == resetToken.username)) {
+                    winston.error(`Invalid reset code for user: ${user.username}`, { req });
                     return res.status(403).send(generateResponseBody({}, messages.auth.resetToken.invalidResetTokenOrUsername));
                 }
 
                 // Hash password and update in database
+                winston.info(`Encrypting password for user: ${user.username}`, { req });
                 const hashedPassword = await bcrypt.hash(req.body.password, 10);
 
                 // Starting transaction
                 await dbController.Begin();
                 transactionStatus = true;
 
+                winston.info(`Updating password for user: ${user.username}`, { req });
                 const response = await dbController.UpdatePasswordAgainstUsername(hashedPassword, user.username);
 
                 if (response) {
+                    winston.info(`Password updated successfully for user: ${user.username}`, { req });
+
+                    winston.info(`Removing reset code assigned to user: ${user.username}`, { req });
                     const resetResponse = await dbController.UpdateResetCode(null, user.username);
                     if (resetResponse) {
+                        winston.info(`Reset code removed successfully for user: ${user.username}`, { req });
+
                         // Committing transaction if all operations are successful
+                        winston.info(`Saving changes to database for user: ${user.username}`, { req });
                         await dbController.Commit();
+                        winston.info(`Changes Saved successfully for user: ${user.username}`, { req });
                         return res.status(200).send(generateResponseBody({}, messages.auth.resetPassword.success));
                     }
+                    winston.error(`Error removing reset code for user: ${user.username}`, { req });
                 }
-                return res.status(500).send(generateResponseBody({}, messages.auth.resetPassword.failed));
+                winston.error(`Error updating password for user: ${user.username}`, { req });
+                return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.resetPassword.failed));
 
             });
         } else {
+            winston.error(`No user found with username: ${req.authorizedUser.username}`, { req });
             return res.status(401).send(generateResponseBody({}, messages.generalResponse.noUserFound));
         }
     } catch (error) {
         // Rolling back transaction if any operation fails
         transactionStatus && await dbController.Rollback();
-        return res.status(500).send(generateResponseBody({}, messages.auth.resetPassword.failed, error.message));
+        winston.error(`Error resetting password for user: ${req.authorizedUser.username}, Error: ${error.message}`, { req });
+        winston.error(`Error Stack: ${error.stack}`, { req });
+        return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.resetPassword.failed, error.message));
     }
 };
 
@@ -241,23 +284,31 @@ const Signup = async (req, res) => {
     try {
 
         // Confirming if userRole is valid
+        winston.info(`Validating if user role is valid.`, { req });
         const userRole = await dbController.GetUserRoleByRoleId(req.body.userRoleId);
 
         // Preventing any high level account creation
+        winston.info(`Checking to make sure user role is unregistered user.`, { req });
         if (!userRole || req.body.userRoleId !== constants.userRoles.UnregisteredUser) {
+            winston.error(`User role is not unregistered user. Rejecting signup.`, { req });
             return res.status(401).send(generateResponseBody({}, messages.systemMessages.unauthorizedOperation));
         }
+        winston.info(`User role is valid.`, { req });
 
         // Starting transaction
+        winston.info(`Starting Signup process.`, { req });
         await dbController.Begin();
         transactionStatus = true;
 
         // Creating User record
+        winston.info(`Creating user record.`, { req });
         const createUserResponse = dbController.CreateUser(req.body);
 
         if (createUserResponse) {
+            winston.info(`User record created successfully.`, { req });
 
             // Creating SystemUser record
+            winston.info(`Creating SystemUser record for ${req.body.identificationNumber} with userId: ${createUserResponse.userId}.`, { req });
             const systemUserResponse = await dbController.CreateSystemUser({
                 userId: createUserResponse.userId,
                 userRoleId: req.body.userRoleId,
@@ -266,18 +317,24 @@ const Signup = async (req, res) => {
             }, req?.authorizedUser?.userId || null);
 
             if (systemUserResponse) {
+                winston.info(`SystemUser record created successfully.`, { req });
 
                 // Committing transaction if all operations are successful
                 await dbController.Commit();
+                winston.info(`User successfully signed up.`, { req });
                 return res.status(201).send(generateResponseBody({}, messages.auth.signup.success));
             }
+            winston.error(`Error creating SystemUser record.`, { req });
         }
 
-        return res.status(500).send(generateResponseBody({}, messages.auth.signup.failed));
+        winston.error(`Error creating user record.`, { req });
+        return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.signup.failed));
 
     } catch (error) {
         transactionStatus && await dbController.Rollback();
-        return res.status(500).send(generateResponseBody({}, messages.auth.signup.failed, error.message));
+        winston.error(`Error signing up user: ${req.body.username}, Error: ${error.message}`, { req });
+        winston.error(`Error Stack: ${error.stack}`, { req });
+        return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.auth.signup.failed, error.message));
     }
 };
 module.exports = {

--- a/api/routes/helpers/userHelper.js
+++ b/api/routes/helpers/userHelper.js
@@ -217,11 +217,11 @@ const CreateEmployee = async (req, res) => {
                 return res.status(201).send(generateResponseBody({ ...systemUserResponse, password: randomPassword }, messages.employee.employeeCreatedSuccessfully));
             }
         }
-        return res.status(500).send(generateResponseBody({}, messages.users.failedToCreateUser));
+        return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.users.failedToCreateUser));
 
     } catch (error) {
         transactionStatus && await dbController.Rollback();
-        return res.status(500).send(generateResponseBody({}, messages.employee.failedToCreateEmployee, error.detail || error.message));
+        return res.status(error.status || error.code || 500).send(generateResponseBody({}, messages.employee.failedToCreateEmployee, error.detail || error.message));
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,3 @@ services:
       dockerfile: api/Dockerfile
     ports:
       - "3000:3000"
-
-  postgres:
-    image: postgres:17.2
-    container_name: postgres_container
-    restart: always
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - ./postgres/init:/docker-entrypoint-initdb.d
-    ports:
-      - "5432:5432"
-    command: bash -c "envsubst < /docker-entrypoint-initdb.d/db_seed_template.sql > /docker-entrypoint-initdb.d/db_seed.sql && docker-entrypoint.sh postgres"


### PR DESCRIPTION
This pull request includes several changes aimed at improving logging and error handling in the authentication helpers, as well as updating environment variable placeholders in the deployment workflow. The most important changes include the addition of detailed logging using `winston` in various authentication functions and the modification of environment variable placeholders in the deployment workflow.

### Logging Improvements:

* Added detailed logging using `winston` to the `AuthenticateConnection`, `Login`, `GenerateResetToken`, `VerifyResetToken`, `ResetPassword`, and `Signup` functions in `api/routes/helpers/authHelper.js`. These logs include information, error, and stack trace messages to help with debugging and monitoring. [[1]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR19) [[2]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR31-R67) [[3]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR77) [[4]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR95-R112) [[5]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR170-R185) [[6]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR204-R272) [[7]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR287-R311)

### Deployment Workflow:

* Updated `.github/workflows/deploy-servers.yml` to replace placeholders in the `.env` file with the correct GitHub Secrets, ensuring that the secrets are correctly referenced.

### Docker Configuration:

* Removed the PostgreSQL service configuration from `docker-compose.yml`. This change eliminates the need for a local PostgreSQL instance in the Docker setup.

### Error Handling:

* Modified error handling in `GenerateResetToken`, `ResetPassword`, `Signup`, and `CreateEmployee` functions to return more specific HTTP status codes based on the error encountered, instead of always returning a 500 status code. [[1]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdL130-R155) [[2]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR204-R272) [[3]](diffhunk://#diff-af4774641096fd171371cda30e8e43fe2953b83f2606c5fd3e550e695f4d24fdR320-R337) [[4]](diffhunk://#diff-a47ec749bd766640a57a7ebd41ffe8b8ee23d804103c4fe246b9d8057704c0b2L220-R224)